### PR TITLE
Included Twitter username and related parameter

### DIFF
--- a/views/challenges/show.jade
+++ b/views/challenges/show.jade
@@ -28,7 +28,7 @@ block content
                                 - if (cc)
                                     a.animated.fadeIn.btn.btn-lg.btn-primary.btn-block.next-button(name='_csrf', value=_csrf, aria-hidden='true') Take me to my next challenge
                                     - if (points && points > 2)
-                                        a.animated.fadeIn.btn.btn-lg.btn-block.btn-twitter(href="https://twitter.com/intent/tweet?text=I%20just%20#{verb}%20Free%20Code%20Camp%20Challenge%20%23#{number}:%20#{name}&url=http%3A%2F%2Ffreecodecamp.com/challenges/#{number}&hashtags=learntocode, javascript" target="_blank")
+                                        a.animated.fadeIn.btn.btn-lg.btn-block.btn-twitter(href="https://twitter.com/intent/tweet?text=I%20just%20#{verb}%20%40FreeCodeCamp%20Challenge%20%23#{number}:%20#{name}&url=http%3A%2F%2Ffreecodecamp.com/challenges/#{number}&hashtags=learntocode, javascript&related=FreeCodeCamp" target="_blank")
                                           i.fa.fa-twitter &nbsp;
                                              = phrase
                                 - else


### PR DESCRIPTION
**Change 1:**

I added the FreeCodeCamp Twitter username as well as the "Related" parameter to the auto tweet text.

This changes the tweet text from:

>I just NUKED Free Code Camp Challenge #6: Use jQuery for Styling http://freecodecamp.com/challenges/12  #learntocode #javascript

to:

>I just NUKED @FreeCodeCamp Challenge #6: Use jQuery for Styling http://freecodecamp.com/challenges/12 #learntocode #javascript

****************
**Change 2:**

Also added the "Related accounts" parameter as per https://dev.twitter.com/web/intents

Which gives Tweet poster an opportunity by Twitter to follow the FreeCodeCamp Twitter account if they haven't done so already done so. Poster's that already follow the FCC account will not see this option.

****************
**To test:**

Unfollow FCC on Twitter, 
complete a challenge ,
Tweet about challenge completion

Expected result:
1) FreeCodeCamp Username in tweet
2) After tweeting opportunity to follow FCC account